### PR TITLE
「データ共有」ボタンを押したら外側のサイトのフォームに反映させる 

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -6,6 +6,7 @@
   height: 100vh;
   min-height: 100vh;
   padding: 0 0.5rem;
+  overflow: hidden;
 }
 
 .main {
@@ -14,7 +15,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 5rem 0;
+  padding: 1rem 0;
 }
 
 .footer {
@@ -22,7 +23,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 100px;
+  height: 50px;
   border-top: 1px solid #eaeaea;
 }
 

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,45 +1,13 @@
 import { IframeHideBtn } from '../scripts/IframeHideBtn';
+import { SendDataForm } from '../scripts/SendDataForm';
 import styles from './index.module.css';
 
 const Home = () => {
   return (
     <div className={styles.container}>
       <main className={styles.main}>
-        <h1 className={styles.title}>
-          Welcome to <a href="https://nextjs.org">Next.js!</a>
-        </h1>
-        <p className={styles.description}>
-          Get started by editing{' '}
-          <code className={styles.code} style={{ backgroundColor: '#fafafa' }}>
-            pages/index.js
-          </code>
-        </p>
-
         <IframeHideBtn />
-        <div className={styles.grid}>
-          <a className={styles.card} href="https://nextjs.org/docs">
-            <h2>Documentation &rarr;</h2>
-            <p>Find in-depth information about Next.js features and API.</p>
-          </a>
-
-          <a className={styles.card} href="https://nextjs.org/learn">
-            <h2>Learn &rarr;</h2>
-            <p>Learn about Next.js in an interactive course with quizzes!</p>
-          </a>
-
-          <a className={styles.card} href="https://github.com/vercel/next.js/tree/master/examples">
-            <h2>Examples &rarr;</h2>
-            <p>Discover and deploy boilerplate example Next.js projects.</p>
-          </a>
-
-          <a
-            className={styles.card}
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-          >
-            <h2>Deploy &rarr;</h2>
-            <p>Instantly deploy your Next.js site to a public URL with Vercel.</p>
-          </a>
-        </div>
+        <SendDataForm />
       </main>
       <footer className={styles.footer}>
         <a

--- a/src/scripts/IframeHideBtn.tsx
+++ b/src/scripts/IframeHideBtn.tsx
@@ -4,8 +4,13 @@ import type { PostData } from './Post.type';
 const hideIframe = () => {
   const postData: PostData = {
     action: 'hide',
-    contents: [],
+    content: {
+      name: '',
+      email: '',
+      old: '',
+    },
   };
+
   window.parent.postMessage(postData, '*');
 };
 

--- a/src/scripts/IframeHideBtn.tsx
+++ b/src/scripts/IframeHideBtn.tsx
@@ -1,7 +1,12 @@
 import styles from './index.module.css';
+import type { PostData } from './Post.type';
 
 const hideIframe = () => {
-  window.parent.postMessage('hide', '*');
+  const postData: PostData = {
+    action: 'hide',
+    contents: [],
+  };
+  window.parent.postMessage(postData, '*');
 };
 
 export const IframeHideBtn = () => {

--- a/src/scripts/Post.type.ts
+++ b/src/scripts/Post.type.ts
@@ -1,9 +1,8 @@
 export type PostData = {
   action: 'hide' | 'share';
-  contents:
-    | {
-        kind: string;
-        value: string;
-      }[]
-    | [];
+  content: {
+    name: string;
+    email: string;
+    old: string;
+  };
 };

--- a/src/scripts/Post.type.ts
+++ b/src/scripts/Post.type.ts
@@ -1,0 +1,9 @@
+export type PostData = {
+  action: 'hide' | 'share';
+  contents:
+    | {
+        kind: string;
+        value: string;
+      }[]
+    | [];
+};

--- a/src/scripts/SendDataForm.tsx
+++ b/src/scripts/SendDataForm.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import type { PostData } from './Post.type';
+import styles from './index.module.css';
+
+export const SendDataForm = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [old, setOld] = useState('');
+  const toShare = () => {
+    const postData: PostData = {
+      action: 'share',
+      contents: [
+        {
+          kind: 'name',
+          value: name,
+        },
+        {
+          kind: 'email',
+          value: email,
+        },
+        {
+          kind: 'old',
+          value: old,
+        },
+      ],
+    };
+    window.parent.postMessage(postData, '*');
+  };
+  return (
+    <div className={styles.container}>
+      <p className={styles.spaceY} />
+      <input
+        title="氏名"
+        className={styles.basicInput}
+        placeholder="富士 太郎"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <p className={styles.spaceY} />
+      <input
+        title="メールアドレス"
+        className={styles.basicInput}
+        placeholder="mail@co.jp"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <p className={styles.spaceY} />
+      <input
+        title="年齢"
+        className={styles.basicInput}
+        placeholder="20"
+        value={old}
+        type="number"
+        onChange={(e) => setOld(e.target.value)}
+      />
+      <p className={styles.spaceY} />
+      <div style={{ textAlign: 'right' }}>
+        <button onClick={toShare} className={styles.shareBtn}>
+          データ共有
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/scripts/SendDataForm.tsx
+++ b/src/scripts/SendDataForm.tsx
@@ -9,23 +9,16 @@ export const SendDataForm = () => {
   const toShare = () => {
     const postData: PostData = {
       action: 'share',
-      contents: [
-        {
-          kind: 'name',
-          value: name,
-        },
-        {
-          kind: 'email',
-          value: email,
-        },
-        {
-          kind: 'old',
-          value: old,
-        },
-      ],
+      content: {
+        name,
+        email,
+        old,
+      },
     };
+
     window.parent.postMessage(postData, '*');
   };
+
   return (
     <div className={styles.container}>
       <p className={styles.spaceY} />

--- a/src/scripts/favoriteBtn.ts
+++ b/src/scripts/favoriteBtn.ts
@@ -20,12 +20,12 @@ type Styles = { property: keyof CSSStyleDeclaration; value: string }[];
 const LOCALHOST_URL = 'http://localhost:3000';
 
 const btnStyle: Styles = [
-  { property: 'width', value: '150px' },
-  { property: 'height', value: '50px' },
+  { property: 'width', value: '160px' },
+  { property: 'height', value: '56px' },
   { property: 'color', value: 'red' },
   { property: 'position', value: 'absolute' },
-  { property: 'top', value: '20%' },
-  { property: 'left', value: '100px' },
+  { property: 'top', value: '160px' },
+  { property: 'left', value: '80px' },
 ];
 
 const containerStyle: Styles = [

--- a/src/scripts/favoriteBtn.ts
+++ b/src/scripts/favoriteBtn.ts
@@ -58,8 +58,7 @@ const showIframe = () => {
 };
 
 const hideIframe = () => {
-  const iframe = container.querySelector('iframe');
-  if (iframe) container.removeChild(iframe);
+  document.body.removeChild(container);
 };
 
 const combineIdentifiers = [

--- a/src/scripts/favoriteBtn.ts
+++ b/src/scripts/favoriteBtn.ts
@@ -37,6 +37,11 @@ const containerStyle: Styles = [
   { property: 'transform', value: 'translate(-50%, -50%)' },
 ];
 
+const containerHideStyle: Styles = [
+  { property: 'height', value: '0' },
+  { property: 'width', value: '0' },
+];
+
 const iframeStyle: Styles = [
   { property: 'height', value: '100%' },
   { property: 'width', value: '100%' },
@@ -64,7 +69,7 @@ const showIframe = () => {
 };
 
 const hideIframe = () => {
-  document.body.removeChild(container);
+  setStyle(container, containerHideStyle);
 };
 
 const combineIdentifiers: { id: string; kind: keyof PostContent }[] = [

--- a/src/scripts/favoriteBtn.ts
+++ b/src/scripts/favoriteBtn.ts
@@ -62,33 +62,33 @@ const hideIframe = () => {
   if (iframe) container.removeChild(iframe);
 };
 
-const targetInputs = [
+const combineIdentifiers = [
   {
-    name: 'q1',
+    id: 'q1',
     kind: 'name',
   },
   {
-    name: 'q2',
+    id: 'q2',
     kind: 'email',
   },
   {
-    name: 'q5',
+    id: 'q5',
     kind: 'old',
   },
 ];
 
 const searchTargetInputs = () => {
   return Array.from(document.getElementsByTagName('input')).filter((elm) =>
-    targetInputs.some((val) => val.name === elm.name)
+    combineIdentifiers.some((val) => val.id === elm.id)
   );
 };
 
 const shareForm = (contents: PostContents) => {
   const inputElms: HTMLInputElement[] = searchTargetInputs();
   if (!inputElms.length) return false;
-  targetInputs.forEach((input) => {
-    const content = contents.find(({ kind }) => kind === input.kind);
-    inputElms.filter(({ name }) => name === input.name)[0].value = content ? content.value : '';
+  combineIdentifiers.forEach((val) => {
+    const content = contents.find(({ kind }) => kind === val.kind);
+    inputElms.filter(({ id }) => id === val.id)[0].value = content ? content.value : '';
   });
   hideIframe();
 };

--- a/src/scripts/favoriteBtn.ts
+++ b/src/scripts/favoriteBtn.ts
@@ -1,13 +1,30 @@
+type PostActions = 'hide' | 'share';
+
+type PostContents = {
+  kind: string;
+  value: string;
+}[];
+
+type PostData = {
+  action: PostActions;
+  contents: PostContents;
+};
+
+type PostFunc = {
+  action: PostActions;
+  func: (contents: PostContents) => void;
+};
+
 type Styles = { property: keyof CSSStyleDeclaration; value: string }[];
 
-const localhostUrl = 'http://localhost:3000';
+const LOCALHOST_URL = 'http://localhost:3000';
 
 const btnStyle: Styles = [
-  { property: 'width', value: '100px' },
+  { property: 'width', value: '150px' },
   { property: 'height', value: '50px' },
   { property: 'color', value: 'red' },
   { property: 'position', value: 'absolute' },
-  { property: 'top', value: '100px' },
+  { property: 'top', value: '20%' },
   { property: 'left', value: '100px' },
 ];
 
@@ -18,6 +35,7 @@ const containerStyle: Styles = [
   { property: 'top', value: '50%' },
   { property: 'left', value: '50%' },
   { property: 'transform', value: 'translate(-50%, -50%)' },
+  { property: 'backgroundColor', value: 'white' },
 ];
 
 const iframeStyle: Styles = [
@@ -33,7 +51,7 @@ const setStyle = (htmlElm: HTMLElement, styles: Styles) => {
 
 const showIframe = () => {
   const iframe = document.createElement('iframe');
-  iframe.src = localhostUrl;
+  iframe.src = LOCALHOST_URL;
   iframe.sandbox.value = 'allow-scripts allow-same-origin';
   setStyle(iframe, iframeStyle);
   container.appendChild(iframe);
@@ -44,8 +62,47 @@ const hideIframe = () => {
   if (iframe) container.removeChild(iframe);
 };
 
+const targetInputs = [
+  {
+    name: 'q1',
+    kind: 'name',
+  },
+  {
+    name: 'q2',
+    kind: 'email',
+  },
+  {
+    name: 'q5',
+    kind: 'old',
+  },
+];
+
+const searchTargetInputs = () => {
+  return Array.from(document.getElementsByTagName('input')).filter((elm) =>
+    targetInputs.some((val) => val.name === elm.name)
+  );
+};
+
+const shareForm = (contents: PostContents) => {
+  const inputElms: HTMLInputElement[] = searchTargetInputs();
+  if (!inputElms.length) return false;
+  targetInputs.forEach((input) => {
+    const content = contents.find(({ kind }) => kind === input.kind);
+    inputElms.filter(({ name }) => name === input.name)[0].value = content ? content.value : '';
+  });
+  hideIframe();
+};
+
+const iframePostActions: PostFunc[] = [
+  { action: 'hide', func: hideIframe },
+  { action: 'share', func: shareForm },
+];
+
 window.addEventListener('message', (event) => {
-  if (event.origin === localhostUrl) hideIframe();
+  if (event.origin !== LOCALHOST_URL) return false;
+  const postData: PostData = event.data;
+  const actionFunc = iframePostActions.filter((val) => val.action === postData.action);
+  actionFunc[0].func(postData.contents);
 });
 
 const btn = document.createElement('button');

--- a/src/scripts/favoriteBtn.ts
+++ b/src/scripts/favoriteBtn.ts
@@ -29,18 +29,18 @@ const btnStyle: Styles = [
 ];
 
 const containerStyle: Styles = [
-  { property: 'height', value: '800px' },
-  { property: 'width', value: '600px' },
+  { property: 'height', value: '50%' },
+  { property: 'width', value: '50%' },
   { property: 'position', value: 'absolute' },
   { property: 'top', value: '50%' },
   { property: 'left', value: '50%' },
   { property: 'transform', value: 'translate(-50%, -50%)' },
-  { property: 'backgroundColor', value: 'white' },
 ];
 
 const iframeStyle: Styles = [
   { property: 'height', value: '100%' },
   { property: 'width', value: '100%' },
+  { property: 'background', value: 'white' },
 ];
 
 const setStyle = (htmlElm: HTMLElement, styles: Styles) => {

--- a/src/scripts/index.module.css
+++ b/src/scripts/index.module.css
@@ -1,37 +1,36 @@
 .hideBtn {
-  width: 200px;
-  height: 100px;
-  font-size: 18px;
+  width: 240px;
+  height: 80px;
+  font-size: 24px;
   cursor: pointer;
   background-color: palegreen;
   border: none;
-  border-radius: 25px;
+  border-radius: 24px;
 }
 
 .shareBtn {
-  width: 150px;
-  height: 30px;
-  margin: 0 0 0 auto;
-  font-size: 18px;
+  width: 192px;
+  height: 32px;
   cursor: pointer;
   background-color: steelblue;
   border: none;
-  border-radius: 10px;
+  border-radius: 8px;
 }
 
 .basicInput {
   width: 100%;
-  height: 30px;
-  padding: 5px;
+  height: 40px;
+  padding: 8px;
+  font-size: 24px;
   border: 1px blue solid;
-  border-radius: 10px;
+  border-radius: 8px;
 }
 
 .spaceY {
-  height: 30px;
+  height: 32px;
   margin: 0;
 }
 
 .container {
-  width: 500px;
+  width: 640px;
 }

--- a/src/scripts/index.module.css
+++ b/src/scripts/index.module.css
@@ -2,7 +2,36 @@
   width: 200px;
   height: 100px;
   font-size: 18px;
+  cursor: pointer;
   background-color: palegreen;
   border: none;
   border-radius: 25px;
+}
+
+.shareBtn {
+  width: 150px;
+  height: 30px;
+  margin: 0 0 0 auto;
+  font-size: 18px;
+  cursor: pointer;
+  background-color: steelblue;
+  border: none;
+  border-radius: 10px;
+}
+
+.basicInput {
+  width: 100%;
+  height: 30px;
+  padding: 5px;
+  border: 1px blue solid;
+  border-radius: 10px;
+}
+
+.spaceY {
+  height: 30px;
+  margin: 0;
+}
+
+.container {
+  width: 500px;
 }


### PR DESCRIPTION
#### 課題内容
React側に氏名など主要なフォームを3つくらい設置し「データ共有」ボタンを押したらiframeは閉じて、外側のサイトのフォームに反映させる
外側のサイトのDOM構造に依存するので公共系の大手サイトに固定するのが良いと思う
他のメンバーも同じサイトを使うことになる

#### 実行結果
1. フォーム反映前
 ![image](https://github.com/user-attachments/assets/80d2c254-a242-4768-afa6-7541c1913a91)
2. 共有情報入力
 ![image](https://github.com/user-attachments/assets/8645497c-6a94-4cc9-8e0b-be39b937447d)
3. データ共有実行
 ![image](https://github.com/user-attachments/assets/b873cd7e-8b8d-4e2d-a6fc-4a7e26fa995e)
